### PR TITLE
Some minor modifications, for an upcoming workshop

### DIFF
--- a/IDE/eaad.lpi
+++ b/IDE/eaad.lpi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="9"/>
+    <Version Value="10"/>
     <PathDelim Value="\"/>
     <General>
       <SessionStorage Value="InProjectDir"/>
@@ -15,9 +15,6 @@
       <EnableI18N Value="True"/>
       <OutDir Value="..\Release\languages"/>
     </i18n>
-    <VersionInfo>
-      <StringTable ProductVersion=""/>
-    </VersionInfo>
     <BuildModes Count="3">
       <Item1 Name="Default" Default="True"/>
       <Item2 Name="Debug">
@@ -64,7 +61,7 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="..\..\Release\eaad"/>
+            <Filename Value="..\Release\eaad"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
@@ -174,7 +171,7 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="..\Release\eaad"/>
+      <Filename Value=".\Release\eaad"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>

--- a/IDE/uglobals.pas
+++ b/IDE/uglobals.pas
@@ -60,7 +60,7 @@ resourcestring
   S_INVALID_PROCESS_NUMBER = 'Invalid Process Number';
   S_INVALID_SECTION = 'Invalid section';
 
-  S_DEFAULT_FILENAME = 'NewAdventure.txp';
+  S_DEFAULT_FILENAME = 'NewAdventure.SCE';
   S_NEWGAME_FILES_NOT_FOUND = 'One or more files required to create a new game are missing, please check your installation.';
 
   //UOptions

--- a/IDE/umain.pas
+++ b/IDE/umain.pas
@@ -5,7 +5,7 @@ unit UMain;
 interface
 
 uses
-   {$IFDEF Windows}windows,{$endif} Classes, SysUtils, FileUtil, SynHighlighterAny,
+   {$IFDEF Windows}windows,{$endif} Classes, SysUtils, LazFileUtils, SynHighlighterAny,
    SynEdit, ExtendedNotebook, Forms, Controls, Graphics, Dialogs, Menus,
    ExtCtrls, ComCtrls, StdCtrls, Buttons, UConfig, usce, UAbout, SynEditTypes,
    SynCompletion, Clipbrd, LCLTranslator, types, LCLType;

--- a/IDE/uoptions.pas
+++ b/IDE/uoptions.pas
@@ -5,7 +5,7 @@
 interface
 
 uses
-  Classes, SysUtils, FileUtil, Forms, Controls, Graphics, Dialogs, ComCtrls,
+  Classes, SysUtils, LazFileUtils, Forms, Controls, Graphics, Dialogs, ComCtrls,
   StdCtrls, Menus, UConfig, DefaultTranslator;
 
 type

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,0 +1,22 @@
+Install Guide for Debian x64
+----------------------------
+From the shell prompt:
+
+$ apt-get install lazarus
+$ git clone https://github.com/Utodev/EAAD.git
+$ mkdir -p EAAD/IDE/Release
+$ cp -afrv EAAD/installation_aux_files/* EAAD/Release/.
+$ lazarus-ide EAAD/IDE/eaad.lpi
+
+Within the Lazarus IDE; Execute Menu > Compile
+Once compiled, just run ./EAAD/Release/eaad
+
+Install Guide for Windows 10 x64
+---------------------------------
+*) Download the source code from https://github.com/Utodev/EAAD/archive/master.zip 
+*) Download and install Lazarus https://www.lazarus-ide.org/ 
+*) Extract the Source code files, locate and open EAAD.LPI with Lazarus
+*) Create the EAAD/Release folder, copy the installation_aux_files contents on it
+
+Within the Lazarus IDE; Execute Menu > Compile
+Once compiled, just run ./EAAD/Release/eaad

--- a/WHATSNEW.txt
+++ b/WHATSNEW.txt
@@ -1,1 +1,9 @@
 2018-01-20 - Fixed start.database file, contained a [SUB] character that was messing around with the new processes.
+2018-02-25 - Created a branch for RunZX2018 DAAD Workshop with some modifications. 
+
+- Added and INSTALL text file with some directions for Windows/Linux Users
+- Fixed a small typo at the eaad.es.po language file "Guadar" -> "Guardar"
+- Fixed the SKIP bug at process table 6 on the database.start file. 
+- Changed deprecated FileUtil module at umain.pas,uoptions.pas to LazFileUtils
+- Changed paths of the 'Release' directory at eaad.lpi, so it stays within the EAAD directory
+- Finally, modified the default saving extension of NewAdventure.txp to .SCE at uglobals.pas

--- a/WHATSNEW.txt
+++ b/WHATSNEW.txt
@@ -5,5 +5,5 @@
 - Fixed a small typo at the eaad.es.po language file "Guadar" -> "Guardar"
 - Fixed the SKIP bug at process table 6 on the database.start file. 
 - Changed deprecated FileUtil module at umain.pas,uoptions.pas to LazFileUtils
-- Changed paths of the 'Release' directory at eaad.lpi, so it stays within the EAAD directory
-- Finally, modified the default saving extension of NewAdventure.txp to .SCE at uglobals.pas
+- Changed paths of 'Release' dir at eaad.lpi, stays within the EAAD directory
+- Finally, modified default saving extension of NewAdventure.txp to .SCE at uglobals.pas, as well as into the eaad.es.po, eaad.en.po, eaad.po language files.

--- a/installation_aux_files/database.start
+++ b/installation_aux_files/database.start
@@ -661,7 +661,7 @@ _       _       NOTEQ   255     GFlags  ; menos GFlags!!!
 
 _       _       PLUS    255     1
                 LT      255     255     ; Al final lo dejamos con valor 255
-                SKIP    -1              ; para indicer que hemos inicializado
+                SKIP    -2              ; para indicer que hemos inicializado
 
 _       _       RESET                   ; Objetos a su loc. inicial / Flag 1
                 LET     Strength 10

--- a/installation_aux_files/languages/eaad.en.po
+++ b/installation_aux_files/languages/eaad.en.po
@@ -683,8 +683,8 @@ msgid "EAAD Editor (C) 2015 Uto"
 msgstr "ngPAWS Editor (C) 2015 Uto"
 
 #: uglobals.s_default_filename
-msgid "NewAdventure.txp"
-msgstr "NewAdventure.txp"
+msgid "NewAdventure.SCE"
+msgstr "NewAdventure.SCE"
 
 #: uglobals.s_direction
 msgid "Direction"

--- a/installation_aux_files/languages/eaad.es.po
+++ b/installation_aux_files/languages/eaad.es.po
@@ -663,8 +663,8 @@ msgid "EAAD Editor (C) 2015 Uto"
 msgstr "EAAD Editor (C) 2015 Uto"
 
 #: uglobals.s_default_filename
-msgid "NewAdventure.txp"
-msgstr "NuevaAventura.txp"
+msgid "NewAdventure.SCE"
+msgstr "NuevaAventura.SCE"
 
 #: uglobals.s_direction
 msgid "Direction"

--- a/installation_aux_files/languages/eaad.es.po
+++ b/installation_aux_files/languages/eaad.es.po
@@ -92,7 +92,7 @@ msgstr "Reemplazar"
 
 #: tfmain.bsave.hint
 msgid "Save"
-msgstr "Guadar"
+msgstr "Guardar"
 
 #: tfmain.bundo.hint
 msgctxt "TFMAIN.BUNDO.HINT"

--- a/installation_aux_files/languages/eaad.po
+++ b/installation_aux_files/languages/eaad.po
@@ -618,7 +618,7 @@ msgid "EAAD Editor (C) 2015 Uto"
 msgstr ""
 
 #: uglobals.s_default_filename
-msgid "NewAdventure.txp"
+msgid "NewAdventure.SCE"
 msgstr ""
 
 #: uglobals.s_direction


### PR DESCRIPTION
Hi there,

Here are some minor modifications that may come in handy to the project; some are needed fixes, the last ones are just optional changes.

2018-02-25 
- Created a fork for an upcoming DAAD Workshop with some modifications. 
- Added an INSTALL text file with some directions for Windows/Linux Users
- Fixed a small typo at the eaad.es.po language file "Guadar" -> "Guardar"
- Fixed the SKIP -1 bug at process table 6 on the database.start file. 
- Changed deprecated FileUtil module at umain.pas, uoptions.pas to LazFileUtils
(optional) Changed paths of 'Release' dir at eaad.lpi, so the final compilation stays within the EAAD dir
(optional) Finally, modified default saving extension of NewAdventure.txp to .SCE at uglobals.pas, as well as into the eaad.es.po, eaad.en.po, eaad.po language files (as suggested by DrVanHalen)

(Thanks for the editor!)